### PR TITLE
Limit in-game tips to 3 from level 10 (and random)

### DIFF
--- a/lib/ui/features/game/view_models/game_view_model.dart
+++ b/lib/ui/features/game/view_models/game_view_model.dart
@@ -44,7 +44,11 @@ class GameViewModelState {
     this.isSoundEffectsEnabled = true,
     this.hintFromIndex,
     this.hintToIndex,
+    this.hintsRemaining = 0,
   });
+
+  static const int hintsPerLevel = 3;
+  static const int hintsUnlockLevel = 10;
 
   final GameLevel? level;
   final bool isLoading;
@@ -70,9 +74,16 @@ class GameViewModelState {
   final bool isSoundEffectsEnabled;
   final int? hintFromIndex;
   final int? hintToIndex;
+  final int hintsRemaining;
 
   bool get canUndo => moveHistory.isNotEmpty && !isComplete && !isTimeOut;
 
+  /// Tips button: campaign from level 10, or any random run. Independent of settings toggle.
+  bool get showHintButton {
+    if (isComplete || isTimeOut || level == null) return false;
+    if (isRandomMode) return true;
+    return level!.levelNumber >= hintsUnlockLevel;
+  }
 
   GameViewModelState copyWith({
     GameLevel? level,
@@ -99,6 +110,7 @@ class GameViewModelState {
     bool? isSoundEffectsEnabled,
     int? Function()? hintFromIndex,
     int? Function()? hintToIndex,
+    int? hintsRemaining,
   }) {
     return GameViewModelState(
       level: level ?? this.level,
@@ -130,6 +142,7 @@ class GameViewModelState {
           hintFromIndex != null ? hintFromIndex() : this.hintFromIndex,
       hintToIndex:
           hintToIndex != null ? hintToIndex() : this.hintToIndex,
+      hintsRemaining: hintsRemaining ?? this.hintsRemaining,
     );
   }
 }
@@ -144,6 +157,14 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
   final LevelGenerator _levelGenerator;
 
   Timer? _timer;
+
+  int _initialHintsFor({required bool isRandom, required int levelNumber}) {
+    if (isRandom) return GameViewModelState.hintsPerLevel;
+    if (levelNumber >= GameViewModelState.hintsUnlockLevel) {
+      return GameViewModelState.hintsPerLevel;
+    }
+    return 0;
+  }
 
   bool _shouldHaveTimer({required bool isRandom, required int levelNumber, required String difficulty}) {
     if (!_progressRepository.isTimerEnabled()) {
@@ -225,6 +246,8 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
         final isInstantPouring = _progressRepository.isInstantPouringEnabled();
         final isHintHelper = _progressRepository.isHintHelperEnabled();
         final isSoundEffects = _progressRepository.isSoundEffectsEnabled();
+        final defaultHints = _initialHintsFor(isRandom: false, levelNumber: levelNumber);
+        final savedHints = savedMap['hintsRemaining'] as int?;
 
         state = GameViewModelState(
           level: level,
@@ -235,6 +258,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
           isInstantPouringEnabled: isInstantPouring,
           isHintHelperEnabled: isHintHelper,
           isSoundEffectsEnabled: isSoundEffects,
+          hintsRemaining: savedHints ?? defaultHints,
         );
 
         if (savedMap['timeLeft'] != null) {
@@ -257,6 +281,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
         isInstantPouringEnabled: isInstantPouring,
         isHintHelperEnabled: isHintHelper,
         isSoundEffectsEnabled: isSoundEffects,
+        hintsRemaining: _initialHintsFor(isRandom: false, levelNumber: levelNumber),
       );
 
       _progressRepository.clearActiveLevelState();
@@ -294,6 +319,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
       isInstantPouringEnabled: isInstantPouring,
       isHintHelperEnabled: isHintHelper,
       isSoundEffectsEnabled: isSoundEffects,
+      hintsRemaining: _initialHintsFor(isRandom: true, levelNumber: -1),
     );
 
     try {
@@ -348,6 +374,8 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
           isBlurSolvedTubesEnabled: isBlurSolved,
           isInstantPouringEnabled: isInstantPouring,
           isHintHelperEnabled: isHintHelper,
+          hintsRemaining: savedMap['hintsRemaining'] as int? ??
+              _initialHintsFor(isRandom: true, levelNumber: -1),
         );
 
         if (savedMap['timeLeft'] != null) {
@@ -632,6 +660,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
       'moveCount': state.moveCount,
       'timeLeft': state.timeLeft,
       'optimalMoves': level.optimalMoves,
+      'hintsRemaining': state.hintsRemaining,
       'tubes': level.tubes.map((t) => {
         'colors': t.colors.map((c) => c.value).toList(),
         'capacity': t.capacity,
@@ -651,6 +680,8 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
 
   bool showHint() {
     if (state.level == null || state.isComplete || state.isTimeOut) return false;
+    if (!state.showHintButton || state.hintsRemaining <= 0) return false;
+
     final solver = LevelSolver();
 
     if (_cachedSolution == null || _cachedSolution!.isEmpty) {
@@ -671,7 +702,9 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
         selectedTubeIndex: () => null,
         hintFromIndex: () => nextMove.fromIndex,
         hintToIndex: () => nextMove.toIndex,
+        hintsRemaining: state.hintsRemaining - 1,
       );
+      _saveCurrentState();
       return true;
     }
     return false;

--- a/lib/ui/features/game/views/game_view.dart
+++ b/lib/ui/features/game/views/game_view.dart
@@ -361,54 +361,62 @@ class _GameViewState extends ConsumerState<GameView> {
               ],
             ),
           ),
-          if (state.isHintHelperEnabled) ...[
+          if (state.showHintButton) ...[
             const SizedBox(width: 12),
-            // Hint Button
+            // Hint Button (campaign ≥10 or random; max 3 per level/run)
             Expanded(
               child: GestureDetector(
-                onTap: () {
-                  final success = ref.read(gameViewModelProvider.notifier).showHint();
-                  if (!success) {
-                    ScaffoldMessenger.of(context).hideCurrentSnackBar();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('No solution possible from current state. Try undoing some moves!'),
-                        duration: Duration(seconds: 2),
-                      ),
-                    );
-                  }
-                },
+                onTap: state.hintsRemaining <= 0
+                    ? null
+                    : () {
+                        final success =
+                            ref.read(gameViewModelProvider.notifier).showHint();
+                        if (!success) {
+                          ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text(
+                                'No solution possible from current state. Try undoing some moves!',
+                              ),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                        }
+                      },
                 behavior: HitTestBehavior.opaque,
-                child: Container(
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFB300).withValues(alpha: 0.12),
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: const Color(0xFFFFB300).withValues(alpha: 0.35),
-                      width: 1.0,
+                child: Opacity(
+                  opacity: state.hintsRemaining <= 0 ? 0.4 : 1,
+                  child: Container(
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFFFB300).withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: const Color(0xFFFFB300).withValues(alpha: 0.35),
+                        width: 1.0,
+                      ),
                     ),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: const [
-                      Icon(
-                        Icons.lightbulb_rounded,
-                        size: 16,
-                        color: Color(0xFFFFB300),
-                      ),
-                      SizedBox(width: 6),
-                      Text(
-                        'HINT',
-                        style: TextStyle(
-                          fontFamily: 'BebasNeue',
-                          fontSize: 14,
-                          fontWeight: FontWeight.w900,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(
+                          Icons.lightbulb_rounded,
+                          size: 16,
                           color: Color(0xFFFFB300),
-                          letterSpacing: 0.8,
                         ),
-                      ),
-                    ],
+                        const SizedBox(width: 6),
+                        Text(
+                          'TIP ${state.hintsRemaining}',
+                          style: const TextStyle(
+                            fontFamily: 'BebasNeue',
+                            fontSize: 14,
+                            fontWeight: FontWeight.w900,
+                            color: Color(0xFFFFB300),
+                            letterSpacing: 0.8,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/ui/features/home/views/settings_view.dart
+++ b/lib/ui/features/home/views/settings_view.dart
@@ -558,13 +558,12 @@ class SettingsView extends ConsumerWidget {
                         onTap: () => ref.read(homeViewModelProvider.notifier).toggleTimer(),
                       ),
                       _buildDivider(),
-                      _buildSettingRow(
+                      _buildInfoRow(
                         icon: Icons.lightbulb_rounded,
                         iconColor: const Color(0xFFFFB300),
-                        title: 'HINT HELPER',
-                        description: 'Show a hint button during gameplay to highlight the next optimal move.',
-                        value: state.isHintHelperEnabled,
-                        onTap: () => ref.read(homeViewModelProvider.notifier).toggleHintHelper(),
+                        title: 'LEVEL TIPS',
+                        description:
+                            'From level 10 (and in random mode) you get 3 tips per puzzle. Each tip highlights the next good pour from your current board. Reset refills tips. Levels 1–9 have no tips.',
                       ),
                       _buildDivider(),
                       _buildSettingRow(
@@ -888,6 +887,61 @@ class SettingsView extends ConsumerWidget {
       color: Color(0xFF1F1F27),
       indent: 68,
       endIndent: 16,
+    );
+  }
+
+  Widget _buildInfoRow({
+    required IconData icon,
+    required Color iconColor,
+    required String title,
+    required String description,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 38,
+            height: 38,
+            decoration: BoxDecoration(
+              color: iconColor.withValues(alpha: 0.16),
+              borderRadius: BorderRadius.circular(11),
+              border: Border.all(
+                color: iconColor.withValues(alpha: 0.35),
+                width: 1.0,
+              ),
+            ),
+            child: Icon(icon, color: iconColor, size: 20),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontFamily: 'BebasNeue',
+                    fontSize: 16,
+                    color: AppColors.headingWhite,
+                    letterSpacing: 0.8,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  description,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: AppColors.subtext,
+                    height: 1.3,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- Campaign levels **1–9**: no tip button
- Campaign **level ≥ 10** and **random mode**: **3 tips** per puzzle
- Each tip uses the existing solver to highlight the next good pour from the **current** board (not tutorial text)
- Failed tip (no solution found) does **not** consume a tip
- **Reset** refills tips to 3
- Settings: replaced the old Hint Helper toggle with a short explanation of the tip rules

## Test plan
- [ ] Levels 1–9: tip button hidden
- [ ] Level 10+: button shows `TIP 3` → decreases on success
- [ ] At `TIP 0`: button disabled
- [ ] Reset level: counter back to 3
- [ ] Random mode: same 3-tip behavior
- [ ] Tip with no solvable path: snackbar, counter unchanged
- [ ] Settings → Gameplay shows LEVEL TIPS info (no toggle)
