### PR TITLE
Fix audio player leak and pour-animation race during fast play

### DIFF
--- a/lib/ui/core/audio/game_audio.dart
+++ b/lib/ui/core/audio/game_audio.dart
@@ -1,0 +1,60 @@
+import 'package:flame_audio/flame_audio.dart';
+
+/// Pooled, rate-limited sound effects.
+///
+/// `FlameAudio.play` allocates a brand new `AudioPlayer` per call and never
+/// disposes it, so rapid taps pile up native players until playback stalls and
+/// the app slows down. Pools reuse a bounded number of players instead.
+class GameAudio {
+  GameAudio._();
+
+  static const String pouring = 'pouring.mp3';
+  static const String tubeComplete = 'tube_complete.mp3';
+  static const String levelComplete = 'level_complete.mp3';
+
+  static const Map<String, int> _maxPlayers = {
+    pouring: 3,
+    tubeComplete: 3,
+    levelComplete: 1,
+  };
+
+  /// Minimum gap between two plays of the same effect, so that spamming moves
+  /// cannot queue up dozens of overlapping copies.
+  static const Map<String, Duration> _minInterval = {
+    pouring: Duration(milliseconds: 90),
+    tubeComplete: Duration(milliseconds: 120),
+    levelComplete: Duration(milliseconds: 500),
+  };
+
+  static final Map<String, AudioPool> _pools = {};
+  static final Map<String, int> _lastPlayedMs = {};
+  static Future<void>? _initFuture;
+
+  static Future<void> init() => _initFuture ??= _load();
+
+  static Future<void> _load() async {
+    for (final entry in _maxPlayers.entries) {
+      try {
+        _pools[entry.key] = await FlameAudio.createPool(
+          entry.key,
+          maxPlayers: entry.value,
+        );
+      } catch (_) {
+        // Missing/undecodable asset: that effect stays silent.
+      }
+    }
+  }
+
+  static void play(String file) {
+    final pool = _pools[file];
+    if (pool == null) return;
+
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    final int? lastMs = _lastPlayedMs[file];
+    final int minMs = (_minInterval[file] ?? Duration.zero).inMilliseconds;
+    if (lastMs != null && nowMs - lastMs < minMs) return;
+    _lastPlayedMs[file] = nowMs;
+
+    pool.start().then((_) {}, onError: (_) {});
+  }
+}

--- a/lib/ui/features/game/view_models/game_view_model.dart
+++ b/lib/ui/features/game/view_models/game_view_model.dart
@@ -148,6 +148,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
   final LevelGenerator _levelGenerator;
 
   Timer? _timer;
+  Timer? _saveDebounce;
 
   bool _shouldHaveTimer({required bool isRandom, required int levelNumber, required String difficulty}) {
     if (!_progressRepository.isTimerEnabled()) {
@@ -188,6 +189,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
 
   Future<void> loadLevel(int levelNumber) async {
     _timer?.cancel();
+    _saveDebounce?.cancel();
     state = const GameViewModelState(isLoading: true);
 
     try {
@@ -284,6 +286,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
     int? seed,
   }) async {
     _timer?.cancel();
+    _saveDebounce?.cancel();
     final int levelSeed = seed ?? DateTime.now().millisecondsSinceEpoch;
     final isSuperHard = _progressRepository.isSuperHardModeEnabled();
     final isBlurSolved = _progressRepository.isBlurSolvedTubesEnabled();
@@ -571,6 +574,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
     Future<void> completeLevel() async {
       if (state.level == null || !state.isComplete || state.isProgressSaved) return;
       state = state.copyWith(isProgressSaved: true);
+      _saveDebounce?.cancel();
       _progressRepository.clearActiveLevelState();
       final moves = state.moveCount;
       final optimal = state.level?.optimalMoves ?? 0;
@@ -592,6 +596,7 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
 
     void resetLevel() {
       _cachedSolution = null;
+      _saveDebounce?.cancel();
       _progressRepository.clearActiveLevelState();
       if (state.level != null) {
         if (state.isRandomMode) {
@@ -629,6 +634,17 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
   }
 
   void _saveCurrentState() {
+    // Serializing the whole board + move history on every tap makes fast play
+    // progressively jankier, so coalesce bursts of moves into one write.
+    _saveDebounce?.cancel();
+    if (state.level == null || state.isComplete) {
+      _progressRepository.clearActiveLevelState();
+      return;
+    }
+    _saveDebounce = Timer(const Duration(milliseconds: 350), _writeCurrentState);
+  }
+
+  void _writeCurrentState() {
     if (state.level == null || state.isComplete) {
       _progressRepository.clearActiveLevelState();
       return;
@@ -692,6 +708,10 @@ class GameViewModel extends StateNotifier<GameViewModelState> {
   @override
   void dispose() {
     _timer?.cancel();
+    if (_saveDebounce?.isActive ?? false) {
+      _saveDebounce!.cancel();
+      _writeCurrentState();
+    }
     super.dispose();
   }
 }

--- a/lib/ui/features/game/views/game_view.dart
+++ b/lib/ui/features/game/views/game_view.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flame/game.dart';
-import 'package:flame_audio/flame_audio.dart';
 
 import 'package:url_launcher/url_launcher.dart';
 
+import 'package:watersort/ui/core/audio/game_audio.dart';
 import 'package:watersort/ui/core/theme/app_colors.dart';
 import 'package:watersort/ui/core/widgets/tangible_button.dart';
 import 'package:watersort/ui/features/game/view_models/game_view_model.dart';
@@ -37,6 +37,7 @@ class GameView extends ConsumerStatefulWidget {
 class _GameViewState extends ConsumerState<GameView> {
   WaterSortGame? _game;
   Timer? _hudSwitchTimer;
+  Timer? _completeSoundTimer;
   bool _showTimerInHud = false;
 
   @override
@@ -68,6 +69,7 @@ class _GameViewState extends ConsumerState<GameView> {
   @override
   void dispose() {
     _hudSwitchTimer?.cancel();
+    _completeSoundTimer?.cancel();
     super.dispose();
   }
 
@@ -93,14 +95,13 @@ class _GameViewState extends ConsumerState<GameView> {
     ref.listen<GameViewModelState>(gameViewModelProvider, (prev, next) {
       if (next.isComplete && !(prev?.isComplete ?? false)) {
         if (!next.isInstantPouringEnabled) {
-          Future.delayed(const Duration(milliseconds: 500), () {
+          _completeSoundTimer?.cancel();
+          _completeSoundTimer = Timer(const Duration(milliseconds: 500), () {
             if (!mounted) return;
             final currentState = ref.read(gameViewModelProvider);
             if (!currentState.isComplete) return;
             if (currentState.isSoundEffectsEnabled) {
-              try {
-                FlameAudio.play('level_complete.mp3');
-              } catch (_) {}
+              GameAudio.play(GameAudio.levelComplete);
             }
             _showCompleteDialog();
           });

--- a/lib/ui/features/game/views/water_sort_game.dart
+++ b/lib/ui/features/game/views/water_sort_game.dart
@@ -2,10 +2,10 @@ import 'dart:math' as math;
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/events.dart';
-import 'package:flame_audio/flame_audio.dart';
 import 'package:flutter/material.dart';
 import 'package:watersort/domain/models/tube.dart';
 import 'package:watersort/ui/features/game/view_models/game_view_model.dart';
+import 'package:watersort/ui/core/audio/game_audio.dart';
 import 'package:watersort/ui/core/theme/app_colors.dart';
 
 class WaterSortGame extends FlameGame with TapCallbacks {
@@ -25,27 +25,46 @@ class WaterSortGame extends FlameGame with TapCallbacks {
   final List<GameParticle> _particles = [];
   final List<TapRipple> _ripples = [];
 
+  static const int _maxParticles = 240;
+  static const int _maxRipples = 6;
+
+  bool _pendingPourHandled = false;
+
   void updateState(GameViewModelState newState) {
-    final bool levelChanged = _state.level != newState.level || _tubes.length != (newState.level?.tubes.length ?? 0);
-    if (levelChanged ||
-        _state.selectedTubeIndex != newState.selectedTubeIndex ||
-        _state.hintFromIndex != newState.hintFromIndex ||
-        _state.hintToIndex != newState.hintToIndex ||
-        _state.isSuperHardModeEnabled != newState.isSuperHardModeEnabled ||
-        _state.isBlurSolvedTubesEnabled != newState.isBlurSolvedTubesEnabled ||
-        _state.isInstantPouringEnabled != newState.isInstantPouringEnabled ||
-        _state.isSoundEffectsEnabled != newState.isSoundEffectsEnabled ||
-        _state.tubeSize != newState.tubeSize) {
-      final bool needRelayout = levelChanged || _state.tubeSize != newState.tubeSize;
-      _state = newState;
-      if (needRelayout) {
-        _layoutTubes();
-      }
-      _syncTubes();
+    final GameViewModelState oldState = _state;
+    final int tubeCount = newState.level?.tubes.length ?? 0;
+    final bool levelChanged = _tubes.length != tubeCount ||
+        oldState.level?.levelNumber != newState.level?.levelNumber ||
+        oldState.randomSeed != newState.randomSeed;
+    // Rebuilding the layout is expensive; the level object identity changes on
+    // every move, so only relayout when the geometry actually changed.
+    final bool needRelayout = levelChanged || oldState.tubeSize != newState.tubeSize;
+
+    _state = newState;
+
+    if (needRelayout) {
+      _layoutTubes();
+    }
+    _syncTubes();
+
+    if (newState.pouringFromIndex == null || newState.pouringToIndex == null) {
+      _pendingPourHandled = false;
+      return;
     }
 
-    if (!newState.isInstantPouringEnabled && newState.pouringFromIndex != null && newState.pouringToIndex != null && _activePour == null) {
-      _startLevelAnimation(newState.pouringFromIndex!, newState.pouringToIndex!);
+    if (newState.isInstantPouringEnabled || _activePour != null || _pendingPourHandled) {
+      return;
+    }
+
+    _pendingPourHandled = true;
+    final bool started = _startLevelAnimation(
+      newState.pouringFromIndex!,
+      newState.pouringToIndex!,
+    );
+    if (!started) {
+      // Nothing to animate. Release the view model instead of leaving it
+      // locked in the "pouring" state, which would ignore every later tap.
+      Future.microtask(onPourComplete);
     }
   }
 
@@ -61,11 +80,9 @@ class WaterSortGame extends FlameGame with TapCallbacks {
         if (newTube.isSolved && !oldTube.isSolved && !newTube.isEmpty) {
           if (!_state.isInstantPouringEnabled) {
             _spawnVictoryBurst(_tubes[i], newTube.topColor ?? const Color(0xFF00FFCC));
-          }
-          if (!_state.isInstantPouringEnabled && _state.isSoundEffectsEnabled) {
-            try {
-              FlameAudio.play('tube_complete.mp3');
-            } catch (_) {}
+            if (_state.isSoundEffectsEnabled) {
+              GameAudio.play(GameAudio.tubeComplete);
+            }
           }
         }
 
@@ -80,8 +97,11 @@ class WaterSortGame extends FlameGame with TapCallbacks {
     }
   }
 
-  void _startLevelAnimation(int fromIndex, int toIndex) {
-    if (fromIndex >= _tubes.length || toIndex >= _tubes.length) return;
+  /// Returns `true` when a pour animation was actually started.
+  bool _startLevelAnimation(int fromIndex, int toIndex) {
+    if (fromIndex < 0 || toIndex < 0 || fromIndex >= _tubes.length || toIndex >= _tubes.length) {
+      return false;
+    }
 
     final fromComp = _tubes[fromIndex];
     final toComp = _tubes[toIndex];
@@ -89,7 +109,7 @@ class WaterSortGame extends FlameGame with TapCallbacks {
     final fromTube = fromComp.tube;
     final toTube = toComp.tube;
 
-    if (fromTube.isEmpty) return;
+    if (fromTube.isEmpty) return false;
     final colorToMove = fromTube.topColor!;
 
     int countToMove = 0;
@@ -104,20 +124,19 @@ class WaterSortGame extends FlameGame with TapCallbacks {
     final availableSpace = toTube.capacity - toTube.colors.length;
     final pourCount = countToMove.clamp(0, availableSpace);
 
-    if (pourCount > 0) {
-      _activePour = ActivePourAnimation(
-        fromComponent: fromComp,
-        toComponent: toComp,
-        color: colorToMove,
-        pourCount: pourCount,
-        duration: _state.isSoundEffectsEnabled ? 0.65 : 0.2,
-      );
-      if (!_state.isInstantPouringEnabled && _state.isSoundEffectsEnabled) {
-        try {
-          FlameAudio.play('pouring.mp3');
-        } catch (_) {}
-      }
+    if (pourCount == 0) return false;
+
+    _activePour = ActivePourAnimation(
+      fromComponent: fromComp,
+      toComponent: toComp,
+      color: colorToMove,
+      pourCount: pourCount,
+      duration: _state.isSoundEffectsEnabled ? 0.65 : 0.2,
+    );
+    if (_state.isSoundEffectsEnabled) {
+      GameAudio.play(GameAudio.pouring);
     }
+    return true;
   }
 
   void _spawnVictoryBurst(TubeComponent tubeComp, Color color) {
@@ -143,18 +162,16 @@ class WaterSortGame extends FlameGame with TapCallbacks {
         ),
       );
     }
+
+    if (_particles.length > _maxParticles) {
+      _particles.removeRange(0, _particles.length - _maxParticles);
+    }
   }
 
   @override
   Future<void> onLoad() async {
-    super.onLoad();
-    try {
-      await FlameAudio.audioCache.loadAll([
-        'pouring.mp3',
-        'tube_complete.mp3',
-        'level_complete.mp3',
-      ]);
-    } catch (_) {}
+    await super.onLoad();
+    await GameAudio.init();
   }
 
   @override
@@ -368,6 +385,9 @@ class WaterSortGame extends FlameGame with TapCallbacks {
     if (tappedTube != null) {
       final center = tappedTube.position + tappedTube.size / 2;
       if (!_state.isInstantPouringEnabled) {
+        if (_ripples.length >= _maxRipples) {
+          _ripples.removeRange(0, _ripples.length - _maxRipples + 1);
+        }
         _ripples.add(
           TapRipple(
             position: center,
@@ -385,6 +405,8 @@ class WaterSortGame extends FlameGame with TapCallbacks {
 
   @override
   void update(double dt) {
+    // A stalled frame must not fast-forward the animations in one jump.
+    if (dt > 0.05) dt = 0.05;
     super.update(dt);
 
     if (_activePour != null) {
@@ -416,7 +438,7 @@ class WaterSortGame extends FlameGame with TapCallbacks {
         _ripples.removeAt(i);
       } else {
         final double t = r.life / r.maxLife;
-        r.radius = r.radius + (r.maxRadius - r.radius) * t;
+        r.radius = r.startRadius + (r.maxRadius - r.startRadius) * t;
       }
     }
   }
@@ -1150,9 +1172,10 @@ class TapRipple {
     required this.life,
     required this.maxLife,
     required this.color,
-  });
+  }) : startRadius = radius;
 
   Vector2 position;
+  final double startRadius;
   double radius;
   double maxRadius;
   double life;


### PR DESCRIPTION

Hello,

A little caveat beforehand. I noticed bug in your game on my device. When I played very fast the sound started getting delayed, not played at all and the app got sluggish and the water sloshing animations got wild. It felt like some kind of race condition or memory leak. 

As I don't write android apps and don't write dart. I thought to see if I could let the AI verify my suspicions. I don't know how you feel about AI for programming, but personally I think this is better than just dump the problem on you without anything else. Below is the reasoning from Opus 5 and it proposed fix, as of yet completely untested. 

I hope it helps. Basically it concluded you call audioplayer over and over without disposing. And if you play fast that stacks. And it rewrote part of you audio engine. 

I hope this is of any use to you. 

==== AI result from here:

Playing many moves in quick succession made sound effects drop out or play late, the pour animation jump, and the app progressively slow down.

Audio
- FlameAudio.play() allocates a new AudioPlayer per call and never disposes it, so every tap leaked a native player. Replace it with bounded, reusable AudioPools (GameAudio) and rate-limit each effect so rapid moves cannot stack overlapping copies of the same sound.
- The try/catch around FlameAudio.play was dead code; play() is async so a synchronous try never caught its errors.

Pour state machine
- _startLevelAnimation could return early (out-of-range index, empty tube, pourCount == 0) leaving _activePour null while the view model still had pouringFromIndex set. selectTube() bails out whenever that is non-null, so the board silently stopped accepting taps. It now reports whether an animation started and releases the view model when none did.
- updateState() did not assign _state when only the pouring indices changed, so the animation was started from the previous state.
- Add a latch so a rebuild cannot re-trigger the same pour.

Performance
- levelChanged compared GameLevel by identity, and a new instance is created on every move, so the full tube layout solver re-ran on every tap. Key it on level number / tube count / seed instead.
- Clamp dt to 50ms so a stalled frame cannot fast-forward the pour animation in a single jump.
- Cap the particle and ripple pools; each ripple draws two blurred strokes, and spamming taps piled them up.
- Debounce the Hive write of the active level state. It serialized the whole board plus the entire move history on every move, so the cost grew with the number of moves played.

Misc
- Fix the frame-rate dependent, self-referencing ripple radius lerp.
- Await super.onLoad().
- Make the delayed level-complete sound cancellable on dispose.